### PR TITLE
Extend the CI, Make games compile with Coq 8.11 & Avoid the omega tactic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: trusty
-sudo: required
+dist: bionic
+os: linux
 language: generic
 
 services:
@@ -8,7 +8,7 @@ services:
 env:
   global:
   - CONTRIB_NAME="games"
-  matrix:
+  jobs:
   - COQ_IMAGE="mathcomp/mathcomp:1.9.0-coq-8.7"
   - COQ_IMAGE="mathcomp/mathcomp:1.9.0-coq-8.8"
   - COQ_IMAGE="mathcomp/mathcomp:1.9.0-coq-8.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ env:
   - COQ_IMAGE="mathcomp/mathcomp:1.9.0-coq-8.8"
   - COQ_IMAGE="mathcomp/mathcomp:1.9.0-coq-8.9"
   - COQ_IMAGE="mathcomp/mathcomp:1.9.0-coq-8.10"
+  - COQ_IMAGE="mathcomp/mathcomp:1.9.0-coq-8.11"
+  - COQ_IMAGE="mathcomp/mathcomp:1.10.0-coq-8.7"
+  - COQ_IMAGE="mathcomp/mathcomp:1.10.0-coq-8.8"
+  - COQ_IMAGE="mathcomp/mathcomp:1.10.0-coq-8.9"
+  - COQ_IMAGE="mathcomp/mathcomp:1.10.0-coq-8.10"
+  - COQ_IMAGE="mathcomp/mathcomp:1.10.0-coq-8.11"
 
 install: |
   # Prepare the COQ container

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 
 env:
   global:
+  - NJOBS="2"
   - CONTRIB_NAME="games"
   jobs:
   - COQ_IMAGE="mathcomp/mathcomp:1.9.0-coq-8.7"
@@ -25,23 +26,21 @@ install: |
   docker pull ${COQ_IMAGE}
   docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
   docker exec COQ /bin/bash --login -c "
-    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
-    set -ex
+    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '; set -ex
     if [ -n \"\${COMPILER_EDGE}\" ]; then opam switch \${COMPILER_EDGE}; eval \$(opam env); fi
     opam update -y
-    opam config list
-    opam repo list
-    opam list
+    opam config list; opam repo list; opam list
     " install
 
 script:
 - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
 - |
   docker exec COQ /bin/bash --login -c "
-    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
-    set -ex
+    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '; set -ex
     sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
-    ( make -j \$NJOBS && make install )
+    ( make -j $NJOBS && make install )
     " script
-- docker stop COQ  # optional
 - echo -en 'travis_fold:end:script\\r'
+
+after_script:
+- docker stop COQ

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Prerequisites
 
 * `coq` `>= 8.7`
-* `coq-mathcomp-algebra` `1.9.0`
+* `coq-mathcomp-algebra` `>= 1.9.0`
 
 # Build
 

--- a/christodoulou.v
+++ b/christodoulou.v
@@ -304,11 +304,11 @@ Module Christodoulou.
       apply /leP.
       apply negbT in H.  rewrite -ltnNge in H.
       apply leq_case in H. destruct H.
-      have H1: (z = 2) by omega. rewrite H1 => //.
+      have H1: (z = 2) by case: H. rewrite H1 => //.
       apply leq_case in H. destruct H.
-      have H1: (z = S O) by omega. rewrite H1 => //.
+      have H1: (z = S O) by case: H. rewrite H1 => //.
       apply leq_case in H. destruct H.
-      have H1: (z = O) by omega. rewrite H1 => //.
+      have H1: (z = O) by case: H. rewrite H1 => //.
       rewrite ltn0 in H. congruence. }
     have H1: (5%:Q / 3%:Q = 2%:Q / 3%:Q + 1%:Q) by [].
     rewrite H1 -addrA [1%:~R + _] addrC addrA.

--- a/dyadic.v
+++ b/dyadic.v
@@ -120,13 +120,13 @@ Proof.
 Qed.  
 
 Lemma Zpow_pos_div x y :
-  (y < x)%positive -> 
+  (y < x)%positive ->
   (Z.pow_pos 2 x # 1) * / (Z.pow_pos 2 y # 1) == Z.pow_pos 2 (x - y) # 1.
 Proof.
   intros H; rewrite !Z.pow_pos_fold.
   assert (Zpos (x - y) = (Zpos x - Zpos y)%Z) as ->.
   { apply Pos2Z.inj_sub; auto. }
-  rewrite Z.pow_sub_r; try omega.
+  rewrite Z.pow_sub_r; try discriminate.
   rewrite <-Z.pow_sub_r.
   { unfold Qmult, Qinv; simpl.
     assert (exists p, Z.pow_pos 2 y = Zpos p).
@@ -269,8 +269,8 @@ Proof.
       { rewrite Qmult_1_r; apply Qeq_refl. }
       rewrite Zpower_pos_nat, Zpower_nat_Z.
       unfold Qeq; simpl; rewrite Zmult_1_r; apply Z.pow_nonzero.
-      { omega. }
-      omega. }
+      { discriminate. }
+      now auto with zarith. }
     assert (inject_Z (Z.pow_pos 2 (X + Z)) * (1 / inject_Z (Z.pow_pos 2 X)) ==
             inject_Z (Z.pow_pos 2 Z)) as ->.
     { unfold Qdiv.
@@ -284,8 +284,8 @@ Proof.
         { rewrite Qmult_1_r; apply Qeq_refl. }
         unfold inject_Z; rewrite Zpower_pos_nat, Zpower_nat_Z.
         unfold Qeq; simpl; rewrite Zmult_1_r; apply Z.pow_nonzero.
-        { omega. }
-        omega. }
+        { discriminate. }
+        now auto with zarith. }
       rewrite Qmult_1_r; apply Qeq_refl. }
     unfold D_to_Q; simpl.
     rewrite <-inject_Z_mult, <-inject_Z_plus.
@@ -316,8 +316,8 @@ Proof.
       { rewrite Qmult_1_r; apply Qeq_refl. }
       rewrite Zpower_pos_nat, Zpower_nat_Z.
       unfold Qeq; simpl; rewrite Zmult_1_r; apply Z.pow_nonzero.
-      { omega. }
-      omega. }
+      { discriminate. }
+      now auto with zarith. }
     assert (inject_Z (Z.pow_pos 2 (X + Z)) * (1 / inject_Z (Z.pow_pos 2 Z)) ==
             inject_Z (Z.pow_pos 2 X)) as ->.
     { unfold Qdiv.
@@ -330,8 +330,8 @@ Proof.
         { rewrite Qmult_1_r; apply Qeq_refl. }
         unfold inject_Z; rewrite Zpower_pos_nat, Zpower_nat_Z.
         unfold Qeq; simpl; rewrite Zmult_1_r; apply Z.pow_nonzero.
-        { omega. }
-        omega. }
+        { discriminate. }
+        now auto with zarith. }
       rewrite Qmult_1_r; apply Qeq_refl. }
     unfold D_to_Q; simpl.
     rewrite <-inject_Z_mult, <-inject_Z_plus.
@@ -520,7 +520,7 @@ Proof.
   rewrite Zmult_comm.
   rewrite (Pos2Z.inj_xO y).
   apply Zmult_le_compat_l; auto.
-  omega.
+  now auto with zarith.
 Qed.
 
 Lemma two_power_pos_le x y :
@@ -535,36 +535,30 @@ Proof.
   generalize (Pos.to_nat y) as y'; intro.
   revert y'.
   induction x'; simpl.
-  { intros y' _; induction y'; simpl; try solve[intros; omega].
+  { intros y' _; induction y'; simpl; try solve[intros; auto with zarith].
     rewrite Pos2Z.inj_xO.
     assert ((1=1*1)%Z) as -> by (rewrite Zmult_1_r; auto).
-    apply Zmult_le_compat; try omega. }
-  induction y'; try solve[intros; omega].
+    apply Zmult_le_compat; auto with zarith. }
+  induction y'; try solve[intros; auto with zarith].
   simpl; intros H.
   rewrite Pos2Z.inj_xO.
   rewrite
     (Pos2Z.inj_xO
-       (nat_rect (fun _ : nat => positive) 1%positive 
-                 (fun _ : nat => xO) y')).  
-  apply Zmult_le_compat; try omega.
-  { apply IHx'; omega. }
-  clear - x'.
-  induction x'; try (simpl; omega).
-  simpl; rewrite Pos2Z.inj_xO.
-  assert ((0=0*0)%Z) as -> by (rewrite Zmult_0_r; auto).
-  apply Zmult_le_compat; try omega.
-Qed.  
+       (nat_rect (fun _ : nat => positive) 1%positive
+                 (fun _ : nat => xO) y')).
+  now apply Zmult_le_compat; auto with zarith.
+Qed.
 
 Lemma Zpow_pos_size_le x : (x <= Z.pow_pos 2 (Zsize x))%Z.
 Proof.
   destruct x; simpl.
   { rewrite <-two_power_pos_correct.
-    unfold two_power_pos; rewrite shift_pos_equiv; simpl; omega. }
+    now unfold two_power_pos; rewrite shift_pos_equiv; auto with zarith. }
   { generalize (Pos.lt_le_incl _ _ (Pos.size_gt p)).
     rewrite <-Pos2Z.inj_pow_pos; auto. }
   rewrite <-Pos2Z.inj_pow_pos.
   apply Zle_neg_pos.
-Qed.  
+Qed.
 
 Lemma Pos_succ_sub_1 p : (Pos.succ p - 1 = p)%positive.
 Proof.
@@ -577,8 +571,8 @@ Proof.
   apply nat_of_P_gt_Gt_compare_complement_morphism.
   rewrite !Pos2Nat.inj_succ.
   rewrite Pos2Nat.inj_1.
-  omega.
-Qed.  
+  now auto with arith.
+Qed.
 
 Lemma Pos_le_1_add_sub x : (x <= 1 + (x - 1))%positive.
 Proof.
@@ -602,8 +596,8 @@ Proof.
   { apply Nat.le_lt_trans with (m := S (Pos.iter_op Init.Nat.add p 1%nat)); auto.
     assert (H3: (1 <= Pos.iter_op Init.Nat.add p 1)%nat) by apply le_Pmult_nat.
     apply Peano.le_n_S; auto. }
-  omega.
-Qed.  
+  now apply Nat.le_ngt in H2; apply H2; constructor.
+Qed.
 
 Lemma Pos2Nat_inj_2 : Pos.to_nat 2 = 2%nat.
 Proof. unfold Pos.to_nat; simpl; auto. Qed.
@@ -642,12 +636,12 @@ Proof.
     clear - H H0.
     rewrite Pos2Nat.inj_1 in H|-*.
     rewrite Pos2Nat_inj_2 in H0.
-    omega. }
+    now apply Nat.le_antisymm; auto with arith. }
   destruct (Pos.eqb_spec x 2).
   { (*x=2*)
     subst x.
     simpl.
-    omega. }
+    now constructor. }
   assert (H3: Pos.compare_cont Eq x 2 = Gt).
   { apply nat_of_P_gt_Gt_compare_complement_morphism.
     rewrite Pos2Nat.inj_le in H, H0.
@@ -657,14 +651,14 @@ Proof.
     { intros Hx.
       rewrite <-Pos2Nat.inj_iff, Hx in n0.
       auto. }
-    omega. }
+    now auto with zarith. }
   rewrite nat_of_P_minus_morphism; auto.
   simpl.
   assert (Pos.to_nat 1 = 1%nat) as -> by auto.
   assert (Pos.to_nat 2 = 2%nat) as -> by auto.
   apply Peano.le_n_S.
   generalize (Pos.to_nat x) as m; intro.
-  induction m; try solve[omega].
+  now destruct m; auto with zarith.
 Qed.
 
 Lemma Psize_minus_aux (x y : positive) : (x <= Pos.div2 (2^y) + (x - y))%positive.
@@ -695,7 +689,7 @@ Proof.
   { rewrite Pos.sub_succ_r.
     destruct (Pos.eqb_spec (x-z) 1).
     { rewrite e; simpl.
-      rewrite Pos2Nat.inj_le, Pos2Nat.inj_1, Pos2Nat_inj_2; omega. }
+      now rewrite Pos2Nat.inj_le, Pos2Nat.inj_1, Pos2Nat_inj_2; constructor. }
     rewrite Pos.succ_pred; auto.
     apply Pos.le_refl. }
   generalize H.
@@ -726,13 +720,13 @@ Proof.
     apply nat_of_P_gt_Gt_compare_morphism in H2.
     apply H.
     rewrite Pos.compare_cont_Gt_Gt.
-    rewrite Pos2Nat.inj_ge; omega. }
+    now rewrite Pos2Nat.inj_ge; auto with zarith. }
   { unfold Pos.le, Pos.compare; simpl.
     intros H H2.
     apply H; auto. }
   intros _; apply Pos.le_1_l.
 Qed.
-  
+
 Local Open Scope D_scope.
 
 Lemma Dlub_mult_le1 d : d * Dlub d <= 1.
@@ -753,12 +747,12 @@ Proof.
   rewrite Pos2Nat.inj_add.
   destruct (Pos.ltb_spec y z) as [H|H].
   { rewrite Pos2Nat.inj_sub; auto.
-    omega. }
+    now auto with zarith. }
   assert ((z - y = 1)%positive) as ->.
   { apply Pos.sub_le; auto. }
   revert H; rewrite Pos2Nat.inj_le.
   rewrite Pos2Nat.inj_1.
-  omega.
+  now auto with zarith.
 Qed.
 
 Lemma Dlub_nonneg (d : D) :
@@ -766,11 +760,11 @@ Lemma Dlub_nonneg (d : D) :
 Proof.
   destruct d; simpl; intros H.
   unfold Dle; rewrite D_to_Q0; unfold D_to_Q; simpl.
-  unfold Qle; simpl; omega.
+  now unfold Qle; simpl; auto with zarith.
 Qed.
 
 Lemma Dlub_ok (d : D) :
-  0 <= d -> 
+  0 <= d ->
   Dle 0 (d * Dlub d) /\ Dle (d * Dlub d) 1.
 Proof.
   intros H.

--- a/numerics.v
+++ b/numerics.v
@@ -232,8 +232,10 @@ Proof.
       + rewrite /GRing.mul /=.
         case H0: ((rn + (sn * rn.+1)%Nrec)%coq_nat).
         * have ->: ((rn = 0)%N).
-          { rewrite -mulnE in H0. omega. }
-          have ->: ((sn = 0)%N).
+          { rewrite -mulnE in H0.
+            rewrite -addn1 mulnDr muln1 in H0.
+            by have /plus_is_O [-> _] := H0. }
+            have ->: ((sn = 0)%N).
           { rewrite -mulnE -addn1 in H0.
             case H1: (sn == 0%N).
             move: H1 => /eqP H1. apply H1.
@@ -329,7 +331,7 @@ Lemma Psucc_gt r s :
   (r > s)%coq_nat.
 Proof.
   rewrite /Pos.gt -SuccNat2Pos.inj_compare /gt -nat_compare_gt.
-  omega.
+  now auto with arith.
 Qed.
 
 Lemma Zneg_Zle r s :
@@ -389,7 +391,7 @@ Proof.
   { move: (Zlt_Zneg H).
     apply: Psucc_gt. }
   clear - H2.
-  apply/ltP; omega.
+  now apply/ltP; auto with arith.
 Qed.
 
 Lemma int_to_Z_le (s r : int) :
@@ -473,12 +475,12 @@ Section rat_to_Q_lemmas.
     { apply Nat2Z.is_nonneg. }
     have H2: (Z.lt (Z.neg (Pos.of_succ_nat n0)) 0).
     { apply Zlt_neg_0. }
-    omega.
+    now rewrite -H in H2; exfalso; auto with zarith.
     have H1: (Z.le 0 (Z.of_nat n0)).
     { apply Nat2Z.is_nonneg. }
     have H2: (Z.lt (Z.neg (Pos.of_succ_nat n)) 0).
     { apply Zlt_neg_0. }
-    omega.
+    now rewrite H in H2; exfalso; auto with zarith.
     inversion H. apply SuccNat2Pos.inj_iff in H1. auto.
   Qed.
 
@@ -933,9 +935,10 @@ Section Z_to_int_lemmas.
       }
       {
         apply IHn in H2.
-        rewrite -minus_Sn_m. rewrite !intS H2 addrA => //.
-        omega. omega.
-      } 
+        rewrite -minus_Sn_m; first by rewrite !intS H2 addrA.
+          by auto with zarith.
+          by auto with zarith.
+      }
       case: (Pos.compare_lt_iff q p) => H1 _.
       apply Pos.compare_gt_iff. apply H1 in H => //.
       case: (Pos.compare_lt_iff q p) => H1 H2.
@@ -963,11 +966,11 @@ Section Z_to_int_lemmas.
       {
         apply IHn in H2.
         rewrite -minus_Sn_m. rewrite !intS H2 addrA => //.
-        omega.
+        now auto with zarith.
       }
       by [].
     }
-  Qed.  
+  Qed.
 
   Lemma Z_to_int_plus (r s : Z) :
     Z_to_int (r + s) = (Z_to_int r + Z_to_int s)%R.
@@ -1035,13 +1038,13 @@ Section Z_to_int_lemmas.
     { case: s.
       { move => p H.
         move: (Pos2Z.is_pos p) => H2.
-        omega. }
+        now auto with zarith. }
       { move => p q.
         rewrite /Z.le -(Pos2Z.inj_compare q p) Pos.compare_le_iff Pos2Nat.inj_le.
         move/leP => //. }
       move => p q; move: (Zle_neg_pos p q); move/Zle_not_lt => H H2.
       have H3: Z.pos q <> Z.neg p by discriminate.
-      omega. }
+      now auto with zarith. }
     case: s => //.
     move => p q; move/Zneg_Zle'; rewrite Pos.ge_le_iff Pos2Nat.inj_le.
     move/leP => H.
@@ -1611,9 +1614,9 @@ Proof.
   rewrite nat_of_bin_succ N2Nat.inj_succ => H.
   have H2: (N.to_nat n < N.to_nat m)%N.
   { move: H; move: (N.to_nat n); move: (N.to_nat m) => x y.
-    move/ltP => H; apply/ltP; omega. }
+    by rewrite ltnS. }
   suff: (n < m)%N => //.
-  by apply: (IH _ H2).
-Qed.    
+  exact: IH _ H2.
+Qed.
 
 (** END random lemmas *)


### PR DESCRIPTION
Hi @gstew5 ,

`games` was not compatible with the latest release of Coq - 8.11.0

Hence that PR (see the commit messages for more details).

Hopefully the CI test-build will be green :)

Cc @pPomCo FYI